### PR TITLE
Add script to run pod-install

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -8,6 +8,7 @@
     "start": "react-native start",
     "studio": "studio android",
     "xcode": "xed ios",
+    "pods": "pod-install",
     "lint": "eslint .",
     "lint:fix": "yarn lint --fix",
     "test": "jest --passWithNoTests"


### PR DESCRIPTION
There was already a script in the root package.json to call this script but it was missing in the mobile package.json