### PR TITLE
Fix path for case-senstive file system

### DIFF
--- a/packages/macos/macos/reactnativeuniversalproject.xcodeproj/project.pbxproj
+++ b/packages/macos/macos/reactnativeuniversalproject.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
-				INFOPLIST_FILE = "reactnativeuniversalproject-macos/Info.plist";
+				INFOPLIST_FILE = "reactnativeuniversalproject-macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = (
@@ -548,7 +548,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = 1;
-				INFOPLIST_FILE = "reactnativeuniversalproject-macos/Info.plist";
+				INFOPLIST_FILE = "reactnativeuniversalproject-macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
I ran into a build error with my development setup that uses a case-sensitive file system.
This PR aligns the Info.plist path for macOS with the actual directory name.